### PR TITLE
Update golangci-lint to version 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13
 
 RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh    | sh -s -- -b $(go env GOPATH)/bin v0.9.13
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
From version `1.18.0` to `1.19.1`

[golangci-lint diff](https://github.com/golangci/golangci-lint/compare/31afdf8b047bdd28e8594dd970ab18778a023794...c427c61253c1cb01005d245bd4fd93922d43eb8a)