### PR TITLE
Use golangci prebuilt image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM golang:1.13
+FROM golangci/golangci-lint:v1.21-alpine
 
 RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh    | sh -s -- -b $(go env GOPATH)/bin v0.9.14
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM golangci/golangci-lint:v1.21-alpine
 
 RUN wget -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v0.9.14
 
+RUN apk --no-cache add git && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golangci/golangci-lint:v1.21-alpine
 
-RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh    | sh -s -- -b $(go env GOPATH)/bin v0.9.14
+RUN wget -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v0.9.14
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golangci/golangci-lint:v1.21-alpine
 
-RUN wget -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v0.9.14
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v0.9.14
 
 RUN apk --no-cache add git && \
     rm -rf /var/lib/apt/lists/*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cd "$GITHUB_WORKSPACE"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-cd "$GITHUB_WORKSPACE"
+cd "$GITHUB_WORKSPACE" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+# shellcheck disable=SC2086
 golangci-lint run --out-format line-number ${INPUT_GOLANGCI_LINT_FLAGS} \
   | reviewdog -f=golangci-lint -name="${INPUT_TOOL_NAME}" -reporter="${INPUT_REPORTER:-'github-pr-check'}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
- use pre-built image of golangci-lint https://hub.docker.com/r/golangci/golangci-lint
- change to alpine-based image
  - because it is smaller and cached on GitHub-hosted runners. ref. https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#ubuntu-1804-lts

finally, it is a little faster to build the action: 30s->23s

before: https://github.com/shogo82148/ridgenative/runs/332227635#step:2:1

![image](https://user-images.githubusercontent.com/1157344/70105652-d0a21a00-1684-11ea-8e92-fa1879690184.png)

after:

https://github.com/shogo82148/ridgenative/runs/332248003#step:2:1
![image](https://user-images.githubusercontent.com/1157344/70105627-bb2cf000-1684-11ea-9285-b8ebeb5df30c.png)
