### PR TITLE
fix:  no go files to analyze 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,9 @@
 
 cd "$GITHUB_WORKSPACE" || exit 1
 
+# check whether the file go.mod exists
+[ -f go.mod ] && ( go mod vendor || exit 1 )
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
fix the issue: https://github.com/golangci/golangci-lint/issues/870, 
when the project only has go.mod (without vendor/ dir).  

test case 1 (only go.mod) : 
https://github.com/Hyvi/go-present/runs/413106781 

test  case 2 (only vendor/ dir) : 
https://github.com/Hyvi/govendor/runs/416254159 
