### PR TITLE
fix: optional parameters are missing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ golangci-lint run --out-format line-number ${INPUT_GOLANGCI_LINT_FLAGS} \
   | reviewdog -f=golangci-lint \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
-      -filter-mode="${INPUT_FILTER_MODE}" \
+      -filter-mode="${INPUT_FILTER_MODE:-added}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR:-false}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,6 @@ golangci-lint run --out-format line-number ${INPUT_GOLANGCI_LINT_FLAGS} \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
-      -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+      -fail-on-error="${INPUT_FAIL_ON_ERROR:-false}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}


### PR DESCRIPTION
golangci-lint fails if actions use the pre-build image, such as:

```yaml
jobs:
  golangci-lint:
    name: golangci-lint
    runs-on: ubuntu-latest
    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v1
      - name: golangci-lint
        uses: docker://reviewdog/action-golangci-lint:v1
        with:
          github_token: ${{ secrets.github_token }}
          level: warning
```

The error message is below:

```
invalid boolean value "" for -fail-on-error: parse error
```

This PR fixes the problem.