### PR TITLE
Provide default Github token

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,7 +14,6 @@ jobs:
         # uses: ./ # Build with Dockerfile
         uses: docker://reviewdog/action-golangci-lint:v1 # Pre-built image
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--config=.github/.golangci.yml ./testdata"
 
   golangci-lint-dockerfile:
@@ -27,7 +26,6 @@ jobs:
         uses: ./ # Build with Dockerfile
         # uses: docker://reviewdog/action-golangci-lint:v1 # Pre-built image
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "./testdata"
           tool_name: "golangci-lint-dockerfile"
 
@@ -40,7 +38,6 @@ jobs:
       - name: golangci-lint w/ github-pr-review
         uses: ./ # Build with Dockerfile
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "./testdata"
           tool_name: "golangci-lint-github-pr-review"
           reporter: "github-pr-review"
@@ -54,7 +51,6 @@ jobs:
       - name: golangci-lint w/ github-check
         uses: ./ # Build with Dockerfile
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "./testdata"
           tool_name: "golangci-lint-github-check"
           level: warning
@@ -69,7 +65,6 @@ jobs:
       - name: golangci-lint (All-In-One config)
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--enable-all --exclude-use-default=false ./testdata"
 
   govet:
@@ -81,7 +76,6 @@ jobs:
       - name: govet
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E govet ./testdata"
           tool_name: govet
 
@@ -94,7 +88,6 @@ jobs:
       - name: staticcheck
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E staticcheck ./testdata"
           tool_name: staticcheck
 
@@ -107,7 +100,6 @@ jobs:
       - name: golint
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E golint ./testdata"
           tool_name: golint
           level: warning
@@ -121,7 +113,6 @@ jobs:
       - name: errcheck
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E errcheck ./testdata"
           tool_name: errcheck
           level: warning
@@ -135,7 +126,6 @@ jobs:
       - name: misspell
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E misspell ./testdata"
           tool_name: misspell
           level: info

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -131,8 +131,8 @@ jobs:
         uses: actions/checkout@v1
       - name: misspell
         uses: docker://reviewdog/action-golangci-lint:v1
-          github_token: ${{ secrets.github_token }}
         with:
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E misspell ./testdata"
           tool_name: misspell
           level: info

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,6 +14,7 @@ jobs:
         # uses: ./ # Build with Dockerfile
         uses: docker://reviewdog/action-golangci-lint:v1 # Pre-built image
         with:
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--config=.github/.golangci.yml ./testdata"
 
   golangci-lint-dockerfile:
@@ -65,6 +66,7 @@ jobs:
       - name: golangci-lint (All-In-One config)
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--enable-all --exclude-use-default=false ./testdata"
 
   govet:
@@ -76,6 +78,7 @@ jobs:
       - name: govet
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E govet ./testdata"
           tool_name: govet
 
@@ -88,6 +91,7 @@ jobs:
       - name: staticcheck
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E staticcheck ./testdata"
           tool_name: staticcheck
 
@@ -100,6 +104,7 @@ jobs:
       - name: golint
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E golint ./testdata"
           tool_name: golint
           level: warning
@@ -113,6 +118,7 @@ jobs:
       - name: errcheck
         uses: docker://reviewdog/action-golangci-lint:v1
         with:
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E errcheck ./testdata"
           tool_name: errcheck
           level: warning
@@ -125,6 +131,7 @@ jobs:
         uses: actions/checkout@v1
       - name: misspell
         uses: docker://reviewdog/action-golangci-lint:v1
+          github_token: ${{ secrets.github_token }}
         with:
           golangci_lint_flags: "--disable-all -E misspell ./testdata"
           tool_name: misspell

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ code review experience.
 
 ### `github_token`
 
-**Required**. Default is `${{ github.token }}`
+**Required**. Default is `${{ github.token }}`. If using a pre-built docker image, you must set it explicitly to `github_token: ${{ secrets.github_token }}`.
 
 ### `golangci_lint_flags`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ code review experience.
 
 ### `github_token`
 
-**Required**. Must be in form of `github_token: ${{ secrets.github_token }}`'.
+**Required**. Default is `${{ github.token }}`
 
 ### `golangci_lint_flags`
 
@@ -77,8 +77,6 @@ jobs:
         uses: actions/checkout@v1
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
-        with:
-          github_token: ${{ secrets.github_token }}
 ```
 
 ### Advanced Usage Example
@@ -101,7 +99,6 @@ jobs:
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:
-          github_token: ${{ secrets.github_token }}
           # Can pass --config flag to change golangci-lint behavior and target
           # directory.
           golangci_lint_flags: "--config=.github/.golangci.yml ./testdata"
@@ -116,7 +113,6 @@ jobs:
       - name: golint
         uses: reviewdog/action-golangci-lint@v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E golint"
           tool_name: golint # Change reporter name.
           level: warning # GitHub Status Check won't become failure with this level.
@@ -131,7 +127,6 @@ jobs:
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E errcheck"
           tool_name: errcheck
           level: info
@@ -154,6 +149,5 @@ jobs:
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:
-          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--enable-all --exclude-use-default=false"
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN.'
     required: true
+    default: ${{ github.token }}
   golangci_lint_flags:
     description: 'golangci-lint flags. (golangci-lint run --out-format=line-number <golangci_lint_flags>)'
     default: ''


### PR DESCRIPTION
I [saw that this was possible in some other actions](https://github.com/c-hive/gha-remove-artifacts/blob/master/action.yml#L11-L14). Instead of making every single user always have `github_token: ${{ secrets.github_token }}`, we can just provide this for them, while still allowing them to change it.

Also, we don't have to put `${{ secrets.github_token }}`, we can just put `${{ github.token }}`. [They're equivalent.](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context)

If this works and everyone thinks it's a good idea, I think we should have it in other reviewdog actions too.

Just makes people's workflows a tiny bit less noisy :slightly_smiling_face: 