### PR TITLE
Update examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      # optionally use a specific version of Go rather than the default one
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
 ```
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: golint
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
- bump actions/checkout v2 on examples in README
- add a setting up Go step into the example
  - we need to set up Go if we want to use a specific version of Go rather than the default one
  - e.g. want to use `os.ReadFile`, `io.ReadFile` introduced from Go 1.16 on `ubuntu-20.04` (the default version of Go is 1.15 )
  - addresses  https://github.com/reviewdog/action-golangci-lint/issues/73#issuecomment-813386935
