### PR TITLE
Enable cache golangci-lint result, go build and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,40 @@ jobs:
           golangci_lint_flags: "--disable-all -E errcheck"
           tool_name: errcheck
           level: info
+
+  # Enable cache of golangci-lint result, go build and go dependencies
+  with_cache:
+    name: runner / errcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/golangci-lint
+        key: ${{ runner.os }}-golangcilint-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-golangci-lint-
+
+      - uses: actions/cache@v2
+        if: ${{ inputs.skip-build-cache == 'false' }}
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-
+
+      - uses: actions/cache@v2
+        if: ${{ inputs.skip-pkg-cache == 'false' }}
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+    - name: golangci-lint
+      uses: reviewdog/action-golangci-lint@v1
 ```
 
 ### All-in-one golangci-lint configuration without config file

--- a/README.md
+++ b/README.md
@@ -141,15 +141,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/golangci-lint
-        key: ${{ runner.os }}-golangcilint-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-golangci-lint-
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangcilint-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-
 
       - uses: actions/cache@v2
-        if: ${{ inputs.skip-build-cache == 'false' }}
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
@@ -157,15 +156,14 @@ jobs:
             ${{ runner.os }}-gobuild-
 
       - uses: actions/cache@v2
-        if: ${{ inputs.skip-pkg-cache == 'false' }}
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 
-    - name: golangci-lint
-      uses: reviewdog/action-golangci-lint@v1
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v1
 ```
 
 ### All-in-one golangci-lint configuration without config file

--- a/action.yml
+++ b/action.yml
@@ -9,14 +9,6 @@ inputs:
   golangci_lint_flags:
     description: 'golangci-lint flags. (golangci-lint run --out-format=line-number <golangci_lint_flags>)'
     default: ''
-  skip-pkg-cache:
-    description: "if set to true then the action don't cache or restore ~/go/pkg."
-    default: 'false'
-    required: 'true'
-  skip-build-cache:
-    description: "if set to true then the action don't cache or restore ~/.cache/go-build."
-    default: 'false'
-    required: 'true'
   tool_name:
     description: 'Tool name to use for reviewdog reporter'
     default: 'golangci'
@@ -45,29 +37,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/golangci-lint
-        key: ${{ runner.os }}-golangcilint-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-golangci-lint-
-
-    - uses: actions/cache@v2
-      if: ${{ inputs.skip-build-cache == 'false' }}
-      with:
-        path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-gobuild-
-
-    - uses: actions/cache@v2
-      if: ${{ inputs.skip-pkg-cache == 'false' }}
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,14 @@ inputs:
   golangci_lint_flags:
     description: 'golangci-lint flags. (golangci-lint run --out-format=line-number <golangci_lint_flags>)'
     default: ''
+  skip-pkg-cache:
+    description: "if set to true then the action don't cache or restore ~/go/pkg."
+    default: 'false'
+    required: 'true'
+  skip-build-cache:
+    description: "if set to true then the action don't cache or restore ~/.cache/go-build."
+    default: 'false'
+    required: 'true'
   tool_name:
     description: 'Tool name to use for reviewdog reporter'
     default: 'golangci'
@@ -37,6 +45,29 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/golangci-lint
+        key: ${{ runner.os }}-golangcilint-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-golangci-lint-
+
+    - uses: actions/cache@v2
+      if: ${{ inputs.skip-build-cache == 'false' }}
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-
+
+    - uses: actions/cache@v2
+      if: ${{ inputs.skip-pkg-cache == 'false' }}
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:


### PR DESCRIPTION
Enable cache of golangci-lint result, go-build and dependencies: like as `golangci/golangci-lint-action`.
https://github.com/golangci/golangci-lint-action/blob/7f1a4282b7343b30f26556118203f8c2751845d7/src/cache.ts#L26-L44

Cache enabled job is 1 minute faster than no cache in my environment. (1m22s -> 27s)

Without cache
![image](https://user-images.githubusercontent.com/21254456/115995270-95a3dc00-a615-11eb-9594-73cd93d47344.png)

Cache enabled
![image](https://user-images.githubusercontent.com/21254456/115995281-9dfc1700-a615-11eb-9849-a02483fcfffc.png)
