### PR TITLE
fix fail_on_error input

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -25,4 +25,7 @@ golangci-lint run --out-format line-number ${INPUT_GOLANGCI_LINT_FLAGS} \
       -fail-on-error="${INPUT_FAIL_ON_ERROR:-false}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}
+exit_code=$?
 echo '::endgroup::'
+
+exit $exit_code


### PR DESCRIPTION
Fixed it.
https://github.com/reviewdog/action-golangci-lint/issues/64

When `fail_on_error` is true and golangci-lint is failed, job is not failed.

## reproduce

- `reviewdog.yml`

```yml
name: reviewdog
on: [pull_request]
jobs:
  golangci-lint:
    name: runner / golangci-lint
    runs-on: ubuntu-latest
    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v2

      # optionally use a specific version of Go rather than the default one
      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: "1.16"

      - name: golangci-lint
        uses: reviewdog/action-golangci-lint@v1.20.0
        with:
          workdir: testdata/
          github_token: ${{ github.token }}
          reporter: "github-pr-review"
          fail_on_error: true
```

If you would like, I create an issue that lists other repositories that need to fix, and I will fix them one by one.
https://github.com/reviewdog/reviewdog#public-reviewdog-github-actions
