### PR TITLE
fix: use GITHUB_API_URL as GITHUB_API env var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,7 @@ runs:
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
+        GITHUB_API: ${{ env.GITHUB_API_URL }}
 branding:
   icon: 'check-circle'
   color: 'blue'


### PR DESCRIPTION
When I use reviewdog at GitHub Enterprise Server, I must set `GITHUB_API` environment variable.
GitHub Actions' default environment variable `GITHUB_API_URL` can used as `GITHUB_API`.
ref: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables