### PR TITLE
chore: bump to use go1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       # - name: Set up Go
       #   uses: actions/setup-go@v2
       #   with:
-      #     go-version: '1.16'
+      #     go-version: '1.17'
 
       # no need with v2
       # - uses: actions/cache@v2
@@ -149,7 +149,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v1
         with:
           # optionally use a specific version of Go rather than the latest one
-          go_version: '1.16'
+          go_version: '1.17'
 
           # Can pass --config flag to change golangci-lint behavior and target
           # directory.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/reviewdog/action-golangci-lint
 
-go 1.16
+go 1.17


### PR DESCRIPTION
update the action to the [latest go1.17](https://blog.golang.org/go1.17)