### PR TITLE
Fix: update download url of reviewdog

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -104,7 +104,7 @@ async function tagToVersion(tag: string, owner: string, repo: string): Promise<s
   interface Release {
     tag_name: string;
   }
-  const url = `https://github.com/${owner}/${repo}/releases/${tag}`;
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases/${tag}`;
   const client = new http.HttpClient("action-golangci-lint/v1");
   const headers = { [http.Headers.Accept]: "application/json" };
   const response = await client.getJson<Release>(url, headers);

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ async function run() {
   const tmpdir = await fs.mkdtemp(path.join(runnerTmpdir, "reviewdog-"));
 
   try {
-    const reviewdogVersion = core.getInput("reviewdog_version") || "latest";
+    const reviewdogVersion = core.getInput("reviewdog_version") || process.env["REVIEWDOG_VERSION"];
     const golangciLintVersion = core.getInput("golangci_lint_version") || "latest";
     const goVersion = core.getInput("go_version");
     const goVersionFile = core.getInput("go_version_file");


### PR DESCRIPTION
# WHAT
Update download url of reviewdog.

# WHY
To avoid a below warning

```
🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog
 finding a release for latest
Error: Error: unable to find 'latest' - use 'latest' or see https://github.com/reviewdog/reviewdog/releases for details
```

Same issue [here](https://github.com/reviewdog/reviewdog/issues/1380).

As discussed within issune above, the cause seems to be **silent updates on GitHub**.

I have updated the reviewdog download url for that.

>It does look like they released a silent update that ignores headers for https://github.com/reviewdog/reviewdog/releases/latest, but you can call https://api.github.com/repos/reviewdog/reviewdog/releases/latest instead and get the JSON response.

