### PR TITLE
Add fetch-depth: 0 to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # no need with v2
       # - name: Set up Go
@@ -138,6 +140,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
@@ -160,6 +164,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
@@ -178,6 +184,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: golint
         uses: reviewdog/action-golangci-lint@v2
         with:
@@ -192,6 +200,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v2
         with:
@@ -206,6 +216,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
@@ -227,6 +239,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:


### PR DESCRIPTION
```
level=warning msg="[runner] Can't process result by diff processor: can't prepare diff by revgrep: could not read git repo: error executing git diff \"b00bface\" \"\": exit status 128"
```

In order to prevent this golangci-lint's warning, it is necessary to give `fetch-depth: 0` to `actions/checkout`: https://github.com/golangci/golangci-lint/issues/161#issuecomment-1106412387
Therefore, I modify README accordingly.