### PR TITLE
Bump Node.js v16

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -171,7 +171,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version-file: "package.json"
           cache: "npm"
       - run: npm ci
       - uses: reviewdog/action-eslint@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version-file: "package.json"
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Run golangci-lint with reviewdog",
   "main": "lib/main.js",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "scripts": {
     "build": "tsc",
     "format": "prettier --write **/*.ts",


### PR DESCRIPTION
The actions now requires Node.js 16, but `.github/workflows/reviewdog.yml` workflow still uses v12.
We should use Node.js 16.