### PR TITLE
jest-circus is now default test runner

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,10 @@
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['js', 'ts'],
-  testEnvironment: 'node',
-  testMatch: ['**/*.test.ts'],
-  testRunner: 'jest-circus/runner',
+  moduleFileExtensions: ["js", "ts"],
+  testEnvironment: "node",
+  testMatch: ["**/*.test.ts"],
   transform: {
-    '^.+\\.ts$': 'ts-jest'
+    "^.+\\.ts$": "ts-jest",
   },
-  verbose: true
+  verbose: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "eslint-plugin-import": "2.28.0",
         "eslint-plugin-jest": "27.2.3",
         "jest": "29.6.2",
-        "jest-circus": "29.6.2",
         "js-yaml": "4.1.0",
         "prettier": "2.8.8",
         "ts-jest": "29.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-import": "2.28.0",
     "eslint-plugin-jest": "27.2.3",
     "jest": "29.6.2",
-    "jest-circus": "29.6.2",
     "js-yaml": "4.1.0",
     "prettier": "2.8.8",
     "ts-jest": "29.1.1",


### PR DESCRIPTION
jest-circus is now default test runner.
So, there is need to add jest-circus for direct dependency.