### PR TITLE
Update Node.js to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ inputs:
     required: false
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "check-circle"


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Node.js 16 actions are deprecated.
Therefore, I update Node.js used in this Action to 20.