### PR TITLE
renovate: join @typescript-eslint/parser and eslint-plugin-jest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,9 @@
     },
     {
       "updateTypes": ["patch", "pin", "digest"]
+    },
+    {
+      "matchPackageNames": ["@typescript-eslint/parser", "eslint-plugin-jest"]
     }
   ]
 }


### PR DESCRIPTION
Accoding to https://github.com/reviewdog/action-golangci-lint/pull/566#issuecomment-1629794359 and https://github.com/reviewdog/action-golangci-lint/pull/691#issuecomment-2041307432, `@typescript-eslint/parser` and `eslint-plugin-jest` are interdependent.
Therefore, I fix `renovate.json` to be updated them by renovate in one PR.