### PR TITLE
renovate: add groupName

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
       "updateTypes": ["patch", "pin", "digest"]
     },
     {
+      "groupName": "@typescript-eslint/parser and eslint-plugin-jest",
       "matchPackageNames": ["@typescript-eslint/parser", "eslint-plugin-jest"]
     }
   ]


### PR DESCRIPTION
I add `groupName` to the rule added https://github.com/reviewdog/action-golangci-lint/pull/704 because `@typescript-eslint/parser` and `eslint-plugin-jest are not combined into one PR.