### PR TITLE
CI test: Only activate the pull_request trigger in PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
I only activate the `pull_request` trigger in PR because this trigger and the `push` trigger were activated.