### PR TITLE
Update Go to v1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@
 // So we need the go.mod file in our test modules.
 module github.com/reviewdog/action-golangci-lint
 
-go 1.19
+go 1.23


### PR DESCRIPTION
https://github.com/reviewdog/action-golangci-lint/actions/runs/14047830437/job/39357795900#step:3:90 ( https://github.com/reviewdog/action-golangci-lint/pull/779 )

```
  level=warning msg="[linters_context] copyloopvar: this linter is disabled because the Go version (1.19) of your project is lower than Go 1.22"
  level=warning msg="[linters_context] intrange: this linter is disabled because the Go version (1.19) of your project is lower than Go 1.22"
```

To fix the above error, I update Go to v1.23.