### PR TITLE
.golangci.v1.yml: disable golint

### DIFF
--- a/.github/.golangci.v1.yml
+++ b/.github/.golangci.v1.yml
@@ -13,7 +13,6 @@ linters:
   disable-all: true
   enable:
     - govet
-    - golint
     - misspell
     - errcheck
 


### PR DESCRIPTION
https://github.com/reviewdog/action-golangci-lint/actions/runs/14144534629/job/39630250631#step:3:90 ( https://github.com/reviewdog/action-golangci-lint/pull/790 )

```
  level=warning msg="The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner. Replaced by revive."
  level=error msg="[linters_context] golint: This linter is fully inactivated: it will not produce any reports."
```

I disable golint because golint is deprecated.